### PR TITLE
fix character floating

### DIFF
--- a/src/Environment.jsx
+++ b/src/Environment.jsx
@@ -126,7 +126,7 @@ export default function Environment() {
 			</Plane> */}
 			<StaticCollider>
 				<mesh
-					position={[0, -0.1, 0]}
+					position={[0, 0, 0]}
 					rotation={[-Math.PI / 2, 0, 0]}
 					receiveShadow>
 					<planeGeometry args={[20, 20]} />

--- a/src/Experience.jsx
+++ b/src/Experience.jsx
@@ -35,7 +35,7 @@ export default function Experience() {
 	useControls("Character: ", {
 		ResetPlayer: button(() => {
 			flamingoRef.current?.group?.position.set(0, 0, 0);
-			flamingoRef.current?.resetLinvel();
+			flamingoRef.current?.resetLinVel();
 		}),
 	});
 
@@ -48,12 +48,12 @@ export default function Experience() {
 	useEffect(() => {
 		if (flamingoRef.current?.group && currentRoom) {
 			const roomSpawnPositions = {
-				hall: [0, 0, 1],
-				bedroom: [0, 0, 1],
-				kitchen: [0, 0, 1],
-				library: [0, 0, -1.5],
+				hall: [0, 1, 1],
+				bedroom: [0, 1, 1],
+				kitchen: [0, 1, 1],
+				library: [0, 1, -1.5],
 			};
-			const spawnPos = roomSpawnPositions[currentRoom] || [0, 0, 0];
+			const spawnPos = roomSpawnPositions[currentRoom] || [0, 1, 0];
 			flamingoRef.current.group.position.set(...spawnPos);
 			flamingoRef.current?.resetLinVel();
 		}
@@ -63,7 +63,7 @@ export default function Experience() {
 		if (flamingoRef.current && flamingoRef.current.group && cameraRef.current) {
 			cameraRef.current.moveTo(
 				flamingoRef.current.group.position.x,
-				flamingoRef.current.group.position.y + 0.3,
+				flamingoRef.current.group.position.y + 0.5,
 				flamingoRef.current.group.position.z + 0.2,
 				true
 			);
@@ -90,12 +90,17 @@ export default function Experience() {
 				/>
 				<BVHEcctrl
 					ref={flamingoRef}
-					debug={false}
+					debug={true}
 					animated={true}
-					floatHeight={0.1}
-					// floatDamping={26}
+					floatHeight={0.01}
+					floatDamping={26}
 					capsuleHalfHeight={1}
-					position={[0, 0, 0]}>
+					capsuleRadius={0.5}
+					position={[0, 1, 0]}
+					speed={1.6}
+					linearDamping = {3}
+					angularDamping={3}>
+
 					<FernandoTheFlamingo />
 				</BVHEcctrl>
 			</Bvh>

--- a/src/Room.jsx
+++ b/src/Room.jsx
@@ -88,7 +88,9 @@ export default function Room() {
 
 			{currentRoom === "hall" && (
 				<>
-					<Hall />
+					<StaticCollider>
+						<Hall />
+					</StaticCollider>
 				</>
 			)}
 		</>

--- a/src/characters/Monsters/AstroFlamingo.jsx
+++ b/src/characters/Monsters/AstroFlamingo.jsx
@@ -118,9 +118,9 @@ export const FernandoTheFlamingo = forwardRef(function AstroFlamingo(
 					<group
 						ref={armatureRef}
 						name='CharacterArmature'
-						position={[0, 0, 0]}
+						position={[0, -0.5, 0]}
 						rotation={[-Math.PI / 2, 0, 0]}
-						scale={50}>
+						scale={40}>
 						<primitive object={nodes.Root} />
 						castShadow
 					</group>
@@ -130,7 +130,7 @@ export const FernandoTheFlamingo = forwardRef(function AstroFlamingo(
 						material={materials.Atlas}
 						skeleton={nodes.FernandoTheFlamingo.skeleton}
 						rotation={[-Math.PI / 2, 0, 0]}
-						scale={50}
+						scale={40}
 					/>
 				</group>
 			</group>


### PR DESCRIPTION
I altered some colliders throughout the code - mainly to keep things consistent to make it easier to debug in future.
Adding the `debug={true}` helped me to see what was going on with the character model, and the actual colliders. I've left it on, so you can see for yourself - if you look at the capsule that acts as the collider, the character model is now in line with it. if you look at line 121 in AstroFlamingo.jsx, you can see I set `position={[0, -0.5, 0]}`, this has moved the character model down in line with the capsule and has fixed the issue. This is just an awkward-ism from working with colliders and character models when they don't line up nicely, mostly because the origin of a character model is its feet, and the origin of a collider is its centre (which makes no sense as colliders are used for models!!) I changed the scale of him too, but that was just something I did when testing, in case that was causing the issue - you can change that back to 50 and it'll still work fine.

Please poke me if you need more advice!